### PR TITLE
Skip setupCheckers when SHUTDOWN_MODE is on

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -67,9 +67,14 @@ TRONSCAN_WALLET_ADDRESS=
 
 
 # ---- Optional: shutdown announcement ---------------------------------------
-# Set SHUTDOWN_MODE=true to silence every handler, reply to incoming updates
-# with the farewell in src/middlewares/shutdownMode.ts, AND stop every
-# cron-driven outbound notification (price alerts, shift alerts).
+# Set SHUTDOWN_MODE=true to wind the bot down without taking the process
+# offline. The bot will:
+#   * silence every inbound handler and reply with the farewell in
+#     src/middlewares/shutdownMode.ts
+#   * skip starting setupCheckers() — no cron jobs, no price/shift updaters,
+#     no alert/shift checkers, no payment polling
+#   * additionally short-circuit each outbound notification path as a
+#     belt-and-suspenders safety net
 # Unset to restore the bot.
 
 SHUTDOWN_MODE=

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -49,7 +49,7 @@ simply disable that data source.
 
 | Variable | Description |
 |----------|-------------|
-| `SHUTDOWN_MODE` | Set to `true` to silence every inbound handler (replies with the farewell in `src/middlewares/shutdownMode.ts`) **and** stop every cron-driven outbound notification (price and shift alerts). Unset to restore the bot. |
+| `SHUTDOWN_MODE` | Set to `true` to wind the bot down without taking the process offline. The inbound middleware (`src/middlewares/shutdownMode.ts`) replies with the farewell, `setupCheckers()` is skipped so no cron / price / shift / alert / payment loops start, and the outbound notification paths short-circuit as a safety net. Unset to restore the bot. |
 
 ## Optional: MongoDB tuning
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,7 @@ import { setupStart } from './commands/start'
 import { setupStat, statScenes } from './commands/stat'
 import { bots } from './helpers/bot'
 import { setupI18N } from './helpers/i18n'
+import { isShutdownMode } from './helpers/isShutdownMode'
 import { log } from './helpers/log'
 import { attachUser } from './middlewares/attachUser'
 import { checkTime } from './middlewares/checkTime'
@@ -136,6 +137,15 @@ if (botConfig.appFlags.priceAlertBots) {
     await waitForMongoConnectionOrCrash('app bootstrap')
     for (const bot of bots) {
       botInit(bot)
+    }
+
+    // Kill switch: when SHUTDOWN_MODE is on, only the inbound middleware
+    // (which replies with the farewell) needs to run. Skipping setupCheckers
+    // prevents the continuous price/shift loops from pegging CPU and
+    // starving the polling loop, so the farewell actually reaches users.
+    if (isShutdownMode()) {
+      log.info('SHUTDOWN_MODE is on; skipping cron jobs and monitoring loops.')
+      return
     }
 
     // Start all async tasks (cron and continuous)


### PR DESCRIPTION
## Summary
Production was unresponsive to `/help` even with the inbound `shutdownMode` middleware in place: `setupCheckers()` kept spinning up the price/shift updaters and alert/shift checkers, which pegged the DO App Platform worker at ~100% CPU and starved the Telegraf polling loop so the farewell never made it out.

This PR gates `setupCheckers()` on `isShutdownMode()` in `src/app.ts`. When `SHUTDOWN_MODE=true`, the bot only initialises Telegraf to reply with the farewell — no cron, no price updaters, no alert/shift checkers, no payment polling.

The lower-level notification gates added in #21 stay in place as defence-in-depth for the case where the flag is toggled on an already-running instance.

## Production evidence
DO worker `goose` (app `1cc538dc-0e90-484e-8109-fb51e361b887`) reported `state: UNHEALTHY`, `cpu_usage_percent: 99.92`. Run logs from the merged-but-still-running deployment showed continuous `[CHECK ALERTS] Alert trigger check`, `[CANDLES UPDATER]`, and `[PRICE UPDATER]` activity, plus repeated `Duplicate alert trigger attempt` errors (the lower-level gate skipped the send, so alerts stayed in the cache and re-triggered every poll cycle).

## Test plan
- [x] `npx jest` — 13 suites / 69 tests passing
- [x] `npm run lint`
- [x] `npm run build`
- [ ] After deploy: DO worker drops back to a normal CPU profile and `/help` replies with the farewell within seconds