### PR TITLE
Stop SHUTDOWN_MODE middleware from killing the polling loop

### DIFF
--- a/src/middlewares/shutdownMode.test.ts
+++ b/src/middlewares/shutdownMode.test.ts
@@ -1,13 +1,27 @@
+jest.mock('@/helpers/log', () => ({
+  log: { error: jest.fn(), info: jest.fn() },
+}))
+
+import { log } from '@/helpers/log'
 import { SHUTDOWN_MESSAGE, shutdownMode } from '@/middlewares/shutdownMode'
 
-const makeCtx = () =>
-  ({
-    reply: jest.fn().mockResolvedValue(undefined),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any)
+type Ctx = {
+  chat?: { id: number }
+  reply: jest.Mock
+}
+
+const makeCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
+  chat: { id: 1 },
+  reply: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+})
 
 describe('shutdownMode middleware', () => {
   const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
 
   afterEach(() => {
     process.env = { ...originalEnv }
@@ -17,7 +31,8 @@ describe('shutdownMode middleware', () => {
     delete process.env.SHUTDOWN_MODE
     const ctx = makeCtx()
     const next = jest.fn()
-    await shutdownMode(ctx, next)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await shutdownMode(ctx as any, next)
     expect(next).toHaveBeenCalledTimes(1)
     expect(ctx.reply).not.toHaveBeenCalled()
   })
@@ -26,8 +41,35 @@ describe('shutdownMode middleware', () => {
     process.env.SHUTDOWN_MODE = 'true'
     const ctx = makeCtx()
     const next = jest.fn()
-    await shutdownMode(ctx, next)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await shutdownMode(ctx as any, next)
     expect(next).not.toHaveBeenCalled()
     expect(ctx.reply).toHaveBeenCalledWith(SHUTDOWN_MESSAGE)
+  })
+
+  // The Telegraf 3.x polling loop kills itself permanently on any middleware
+  // throw (telegraf.js fetchUpdates -> handleUpdates rejection sets
+  // polling.started = false). The two cases below pin the two ways this
+  // middleware used to leak a rejection.
+  it('skips chatless updates instead of throwing on ctx.reply', async () => {
+    process.env.SHUTDOWN_MODE = 'true'
+    const ctx = makeCtx({ chat: undefined })
+    const next = jest.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(shutdownMode(ctx as any, next)).resolves.toBeUndefined()
+    expect(next).not.toHaveBeenCalled()
+    expect(ctx.reply).not.toHaveBeenCalled()
+  })
+
+  it('swallows reply failures (e.g. user blocked the bot)', async () => {
+    process.env.SHUTDOWN_MODE = 'true'
+    const ctx = makeCtx({
+      reply: jest.fn().mockRejectedValue(new Error('Forbidden: bot blocked')),
+    })
+    const next = jest.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(shutdownMode(ctx as any, next)).resolves.toBeUndefined()
+    expect(ctx.reply).toHaveBeenCalledWith(SHUTDOWN_MESSAGE)
+    expect(log.error).toHaveBeenCalled()
   })
 })

--- a/src/middlewares/shutdownMode.ts
+++ b/src/middlewares/shutdownMode.ts
@@ -1,6 +1,7 @@
 import { Context } from 'telegraf'
 
 import { isShutdownMode } from '@/helpers/isShutdownMode'
+import { log } from '@/helpers/log'
 
 /* eslint-disable max-len */
 export const SHUTDOWN_MESSAGE = `привет. я сделал гуся пять лет назад — тогда нигде не было удобных алертов по ценам. начал для себя, потом подтянулись люди.
@@ -23,5 +24,18 @@ export const SHUTDOWN_MESSAGE = `привет. я сделал гуся пять
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function shutdownMode(ctx: Context, next: () => any) {
   if (!isShutdownMode()) return next()
-  await ctx.reply(SHUTDOWN_MESSAGE)
+  // Skip updates without a chat (my_chat_member, chat_join_request, etc.).
+  // ctx.reply asserts ctx.chat and throws otherwise; an unhandled throw inside
+  // a middleware kills Telegraf 3.x's polling loop permanently (see
+  // node_modules/telegraf/telegraf.js fetchUpdates: it flips polling.started
+  // to false on any handleUpdates rejection), so a single chatless update
+  // would stop the bot from ever reading another /help.
+  if (!ctx.chat) return
+  try {
+    await ctx.reply(SHUTDOWN_MESSAGE)
+  } catch (e) {
+    // Per-send failures (e.g. user blocked the bot, Telegram rate-limit) must
+    // not escape: same polling-loop kill switch as above.
+    log.error('[SHUTDOWN MODE] reply failed', e)
+  }
 }


### PR DESCRIPTION
## Problem
Production was silent: `/help` never got the farewell reply even with `SHUTDOWN_MODE=true` and the worker `HEALTHY` at 3% CPU.

## Root cause
`node_modules/telegraf/telegraf.js` `fetchUpdates()`:
```js
.then((updates) => ... ? this.handleUpdates(updates) ... : [])
.catch((err) => {
  console.error('Failed to process updates.', err)
  this.polling.started = false   // <- permanent kill
  this.polling.offset = 0
  this.polling.stopCallback && ...
})
```
Any unhandled throw from a middleware flips `polling.started = false` and the next `fetchUpdates()` returns on the first line. The bot never calls `getUpdates` again for the rest of the process lifetime.

`shutdownMode` was throwing because `ctx.reply()` asserts `ctx.chat` and throws on updates that don't have one (`my_chat_member`, `chat_join_request`, …). The deploy log shows the kill happening in the very first poll batch after boot:
```
Bot GooseInvestAlertBot is up and running
SHUTDOWN_MODE is on; skipping cron jobs and monitoring loops.
Error: Telegraf: "reply" isn't available for "undefined::"
    at shutdownMode (/app/dist/middlewares/shutdownMode.js:26:15)
Failed to process updates.
```
One chatless update in the startup batch took every bot in the process off the air. After the farewell went out, blocked-by-user updates kept arriving exactly because users were closing the bot.

## Fix
Two narrow guards in `src/middlewares/shutdownMode.ts`:
- `if (!ctx.chat) return` — chatless updates are no-ops, not throws
- `try/catch` around `ctx.reply` — per-send failures (blocked, rate-limit) are logged and swallowed

The polling loop now survives both.

## Test plan
- [x] `npx jest` — 71 tests passing, two new cases pinning the failure modes:
  - `skips chatless updates instead of throwing on ctx.reply`
  - `swallows reply failures (e.g. user blocked the bot)`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] After deploy: production `/help` replies with the farewell within seconds